### PR TITLE
Review of new add/remove API for virtual pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.html
+++ b/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.html
@@ -1,6 +1,7 @@
 <html>
 
 <head>
+    <meta charset="UTF-8">
     <!-- you don't need ignore=notused in your code, this is just here to trick the cache -->
     <script src="../dist/ag-grid.js?ignore=notused25"></script>
     <script src="exampleInsertRemoveVirtualPaging.js"></script>

--- a/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.html
+++ b/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.html
@@ -17,6 +17,7 @@
         <div>
             <button onclick="insertItemsAt2(1)">Insert 1 Row @ 2</button>
             <button onclick="insertItemsAt2(5)">Insert 5 Rows @ 2</button>
+            <button onclick="removeItem(3, 10)">Delete 10 Rows @ 3</button>
             <button onclick="setRowCountTo200()">Set Row Count to 200</button>
             <button onclick="rowsAndMaxFound()">Print Rows and Max Found</button>
             <button onclick="jumpTo500()">Jump to 500</button>

--- a/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
+++ b/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
@@ -27,7 +27,7 @@ var sequenceId = 1;
 
 // create a bunch of dummy data
 var allOfTheData = [];
-for (var i = 0; i<100; i++) {
+for (var i = 0; i<10; i++) {
     allOfTheData.push(createRowData(sequenceId++));
 }
 
@@ -120,10 +120,10 @@ var dataSource = {
             var lastRow = -1;
             if (allOfTheData.length <= params.endRow) {
                 lastRow = allOfTheData.length;
+                // TODO setVirtualRowCount and maxRowFound in ag-Grid's success callback.
+                gridOptions.api.setVirtualRowCount(lastRow);
             }
             // call the success callback
-            // TODO setVirtualRowCount and maxRowFound in ag-Grid's success callback.
-            gridOptions.api.setVirtualRowCount(allOfTheData.length);
             params.successCallback(rowsThisPage, lastRow);
         }, 500);
     }

--- a/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
+++ b/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
@@ -27,7 +27,7 @@ var sequenceId = 1;
 
 // create a bunch of dummy data
 var allOfTheData = [];
-for (var i = 0; i<1000; i++) {
+for (var i = 0; i<100; i++) {
     allOfTheData.push(createRowData(sequenceId++));
 }
 

--- a/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
+++ b/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
@@ -48,7 +48,12 @@ function insertItemsAt2(count) {
         newDataItems.push(newItem);
     }
 
-    gridOptions.api.insertItemsAtIndex(2, newDataItems);
+    gridOptions.api.refreshVirtualPageCache();
+}
+
+function removeItem(start, limit) {
+    allOfTheData.splice(start, limit);
+    gridOptions.api.refreshVirtualPageCache();
 }
 
 function refreshCache() {
@@ -117,6 +122,8 @@ var dataSource = {
                 lastRow = allOfTheData.length;
             }
             // call the success callback
+            // TODO setVirtualRowCount and maxRowFound in ag-Grid's success callback.
+            gridOptions.api.setVirtualRowCount(allOfTheData.length);
             params.successCallback(rowsThisPage, lastRow);
         }, 500);
     }


### PR DESCRIPTION
  5. Added an example of removing a row
  6. Updated insert row examples to use `refreshVirtualPageCache()` as per advice in documentation
  3. Simplified the example data source for better testing and development purposes
  1. Render special characters (£) correctly in the "full screen" example HTML document.  
  2. Git-ignore build directories

Is there any reason the success callback doesn't or can't call `setVirtualRowCount()`?

Without `setVirtualRowCount()`, rows are lost (on add rows) or duplicated (on delete rows):

#### Initial state with 20 rows

![initial 20 rows](https://cloud.githubusercontent.com/assets/325176/17722144/231a950c-6484-11e6-8e6c-d81dab1d0166.png)

#### After deleting 10 rows

![after delete 10](https://cloud.githubusercontent.com/assets/325176/17722146/231acbe4-6484-11e6-82e3-a65251f225c9.png)

#### After Inserting 5 rows

![after insert 5](https://cloud.githubusercontent.com/assets/325176/17722145/231aaf38-6484-11e6-826f-11c0657a2212.png)