### PR TITLE
More improvements to virtual pagination docs

### DIFF
--- a/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
+++ b/src/javascript-grid-virtual-paging/exampleInsertRemoveVirtualPaging.js
@@ -27,7 +27,7 @@ var sequenceId = 1;
 
 // create a bunch of dummy data
 var allOfTheData = [];
-for (var i = 0; i<1000; i++) {
+for (var i = 0; i<20; i++) {
     allOfTheData.push(createRowData(sequenceId++));
 }
 
@@ -64,18 +64,6 @@ function createNewData(count) {
 
 function removeItem(start, limit) {
     allOfTheData.splice(start, limit);
-
-    // see if we know when the last row is
-    if (gridOptions.api.isMaxRowFound()) {
-        // the grid is aware of the last row, so we need to tell it to reduce the row count
-        gridOptions.api.setVirtualRowCount(allOfTheData.length);
-    } else {
-        // otherwise we don't have to do anything, as the grid is still looking for the
-        // last row. and blank rows at the bottom of the grid will be replace with rows
-        // from further down the list, or if the grid does hit the last row, the last row
-        // will be adjusted by the grid.
-    }
-
     gridOptions.api.refreshVirtualPageCache();
 }
 
@@ -143,6 +131,7 @@ var dataSource = {
             var lastRow = -1;
             if (allOfTheData.length <= params.endRow) {
                 lastRow = allOfTheData.length;
+                gridOptions.api.setVirtualRowCount(lastRow);
             }
             // call the success callback
             params.successCallback(rowsThisPage, lastRow);


### PR DESCRIPTION
Thanks for merging and tidying up #41!  :)

There are still a couple of bugs in the examples if `maxRowFound`;


1. UI flashes twice on delete
  - [See screencast](https://drive.google.com/open?id=0BxTG1cYUtUd3MEN0N3hCOVUxTnM
)
1. Last N rows are lost upon add N rows
  - ![before](https://cloud.githubusercontent.com/assets/325176/17761312/266d0cea-655a-11e6-9eca-80c1b33eb5f7.png)



This PR moves `setVirtualRowCount()` back to `getRows` so that;

1. Delete causes just a single UI change
  - [See screencast](https://drive.google.com/open?id=0BxTG1cYUtUd3REhBS3RXaU14SlU)
1. Rows are not lost on add
  - ![after](https://cloud.githubusercontent.com/assets/325176/17761192/2739853c-6559-11e6-91be-47ef51bdb0e5.png)




