### PR TITLE
Height in ag-grid-react

### DIFF
--- a/src/best-react-data-grid/index.php
+++ b/src/best-react-data-grid/index.php
@@ -90,7 +90,7 @@ include '../documentation-main/documentation_header.php';
         <pre><code>import {AgGridReact} from 'ag-grid-react';</code></pre>
         After the import you can then reference the component inside your JSX definitions.
         See the <i>render()</i> function in MyApp.jsx, it has AgGridReact defined as
-        follows:
+        follows (Make sure that you set the height for the parent element of `<AgGridReact />`):
     <pre><code>&lt;AgGridReact
 
     <span class="codeComment">// listen for events with React callbacks</span>


### PR DESCRIPTION
Though it's obvious to see the actual source code, I guess many people just try copy-pasting the chunk below to see if it works, and will confuse them without this.

Actually there was a [question](http://stackoverflow.com/questions/40835566/ag-grid-react-table-not-displaying/40966032#40966032) on stackoverflow, and I struggled with this a bit too.
